### PR TITLE
token 명령에서 콜백 받은 후 토큰 확인 alert 응답 전송

### DIFF
--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -103,11 +103,13 @@ exports.saveAccessToken = (blogJson) => {
 const startCallbackServer = (blogJson, callback) => {
     let app = express();
     app.listen(5000);
-    app.get('/callback', async (req) => {
+    app.get('/callback', async (req, res) => {
         const code = req.query.code;
         if (code) {
             const accessToken = await getAccessTokenByCode(code, blogJson);
             callback(accessToken);
+            res.write('<script>alert("Access token was taken")</script>')
+            res.send();
         } else {
             print.red('Failed get Authorization Code');
             process.exit();


### PR DESCRIPTION
* /callback으로 액세스 토큰 받은 후 확인 메시지 응답

처음 설정할 때 connection refused가 떠서 약간 헤메서 추가해봅니다.
windows.close()로 바로 닫게 하고 싶었는데 크롬에서 보안 문제상 페이지를 닫을 수 없다고 하네요.
