### PR TITLE
writelastest 명령 추가

### DIFF
--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -70,3 +70,34 @@ const searchInCurrent = function() {
 
     return dir+'/'+markdownFileName;
 };
+
+exports.findMarkdownFileNewest = async () => {
+    return new Promise((resolve)=>{
+        resolve(exports.findMarkdownFile(getNewestFileLocation()))
+    })
+};
+
+const getNewestFileLocation = function () {
+    const dir = process.cwd();
+    const files = fs.readdirSync(dir);
+    let markdownFileName;
+    let latestDate = new Date(-1);
+
+    for (let i = 0, length = files.length; i < length; i++) {
+        if (path.extname(files[i]) === '.md') {
+            modifiedDateOfFile = fs.statSync(files[i]).mtime
+    
+            if(latestDate < modifiedDateOfFile){
+                latestDate = modifiedDateOfFile
+                markdownFileName = files[i];
+            }
+        }
+    }
+
+    if(!markdownFileName){
+        print.red(NOT_FOUND_FILE);
+        throw new Error(NOT_FOUND_FILE);
+    }
+
+    return dir+'/'+markdownFileName;  
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,8 @@ const start = function() {
     if(command === 'write') {
         const filePath = process.argv[3];
         write(filePath);
+    }else if(command === 'writelatest'){
+        write(null, "WriteLatest")
     }else if(command === 'init') {
         const editor = process.argv[3];
         init(editor);
@@ -40,7 +42,8 @@ const start = function() {
         }else{
             print.red('This input is not invalid. \nPlease enter only numbers.');
         }
-    }else{
+    }
+    else{
         print.yellow("markdown-tistory \<command\> \ncommand are init, write, token, show \nexample) \n markdown-tistory init \n markdown-tistory write");
         process.exit();
     }
@@ -158,7 +161,7 @@ const showJson = function (inputEditor) {
     });
 };
 
-const write = function(targetLocation) {
+const write = function(targetLocation, isLatestCommand) {
     let blogJson;
     let accessToken;
 
@@ -169,6 +172,7 @@ const write = function(targetLocation) {
         })
         .then((json) => {
             blogJson = json;
+            if(isLatestCommand) return fileFinder.findMarkdownFileNewest();
             return fileFinder.findMarkdownFile(targetLocation);
         })
         .then((markdownFile)=>{

--- a/test/file-finder-test.js
+++ b/test/file-finder-test.js
@@ -6,6 +6,7 @@
 
 const fileFinder = require('../lib/file-finder');
 const assert  = require('assert');
+const fs = require('fs')
 
 describe('file-finder 테스트', () => {
     describe('실행위치에서 파일 찾기', () => {
@@ -25,6 +26,24 @@ describe('file-finder 테스트', () => {
                     assert.equal(markdownFile.title, 'PARSER');
                     done();
                 });
+        });
+    });
+    describe('상대적으로 새로운 파일 찾기', ()=>{
+        before('test 실행 위치에서 실행되므로, \
+            test의 Z_Newest_File.md를 test 실행 위치로 옮긴다',()=>{
+                fs.createReadStream('README.md').pipe(fs.createWriteStream('newREADME.md'));
+            });
+        
+        it('새로 복사된 newREADME를 찾는다', (done) => {
+            fileFinder.findMarkdownFileNewest()
+                .then((markdownFile) => {
+                    assert.equal(markdownFile.title, 'newREADME');
+                    done();
+            });
+        });
+
+        after('완료 후 복사한 RENAME.md를 지운다', ()=>{
+            fs.unlinkSync('newREADME.md');
         });
     });
 });


### PR DESCRIPTION
* 가장 최근에 추가된 md 파일을 포스트하는 writelatest 명령 추가

HEAD에서 별도의 브랜치로 만든 다음에 PR하는게 맞나 모르겠네요
상대경로 write가 무조건 현재 디렉터리의 첫번째 순서의 마크다운 문서를 불러오길래 추가해봤습니다
