### PR TITLE
Update README - Airplay 수신 모드 해제 안내 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ markdown-tistory ad 에디터
 
 * 게시글의 제목은 **마크다운 파일명**을 기준으로 합니다.
 
+* mac에서 토큰 발급 시 `시스템 환경설정 > 공유 > AirPlay 수신 모드 해제` 후 진행해주세요. ([관련이슈](https://github.com/jojoldu/markdown-tistory/issues/19))
 
 ## 4. Release Note
 


### PR DESCRIPTION
관련이슈: https://github.com/jojoldu/markdown-tistory/issues/19 

토큰 발급 시 Airplay 수신 모드가 켜져 있으면 5000 port가 점유되어서 에러가 발생합니다.
README에 안내 추가하면 좋을 것 같습니다!